### PR TITLE
Fix DetailedDns A record endpoint whitespace

### DIFF
--- a/espionage/modules/website/detailed_dns.py
+++ b/espionage/modules/website/detailed_dns.py
@@ -194,7 +194,7 @@ class DetailedDns:
         """
         dns_info = []
         endpoints = [
-            "http://www.dns-lg.com/us01/" + self._domain + "/a ",
+            "http://www.dns-lg.com/us01/" + self._domain + "/a",
             "http://www.dns-lg.com/us01/" + self._domain + "/cert",
             "http://www.dns-lg.com/us01/" + self._domain + "/dhc" + "id",
             "http://www.dns-lg.com/us01/" + self._domain + "/cname",

--- a/tests/test_detailed_dns.py
+++ b/tests/test_detailed_dns.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from espionage.modules.website.detailed_dns import DetailedDns
+
+
+class TestDetailedDns(unittest.TestCase):
+    """Detailed DNS record fetching tests."""
+
+    def test_a_record_endpoint_is_trimmed(self):
+        domain = "example.com"
+        detailed_dns = DetailedDns(domain)
+        requested_urls = []
+
+        def fake_get(url, headers=None, verify=None, timeout=None):
+            requested_urls.append(url)
+
+            class DummyResponse:
+                @staticmethod
+                def json():
+                    return {}
+
+            return DummyResponse()
+
+        with patch("requests.get", side_effect=fake_get):
+            detailed_dns.dns_records()
+
+        expected_endpoint = f"http://www.dns-lg.com/us01/{detailed_dns._domain}/a"
+        self.assertIn(expected_endpoint, requested_urls)
+        self.assertNotIn(expected_endpoint + "%20", requested_urls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure the DetailedDns A-record endpoint string no longer includes a trailing space
- add a unit test that patches requests.get to assert the A-record call uses the /a endpoint

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cf4db51ba0832d8f1c5fed5bb8f6d1